### PR TITLE
[PR] Allow user creation from the Faculty AD group

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( 'facsen.wsu.edu' === get_site()->domain || 'stage.web.wsu.edu' === get_site()->domain ) {
+if ( 'facsen.wsu.edu' === get_site()->domain ) {
 	require_once __DIR__ . '/includes/comments.php';
 	require_once __DIR__ . '/includes/voting.php';
 	require_once __DIR__ . '/includes/faculty-user-signup.php';

--- a/functions.php
+++ b/functions.php
@@ -3,6 +3,7 @@
 if ( 'facsen.wsu.edu' === get_site()->domain || 'stage.web.wsu.edu' === get_site()->domain ) {
 	require_once __DIR__ . '/includes/comments.php';
 	require_once __DIR__ . '/includes/voting.php';
+	require_once __DIR__ . '/includes/faculty-user-signup.php';
 }
 
 add_filter( 'spine_child_theme_version', 'wsu_president_theme_version' );

--- a/includes/faculty-user-signup.php
+++ b/includes/faculty-user-signup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WSU\President\Faculty_User_Signup;
+
+// If a user authenticates with WSU AD, and they don't exist as a user, add them as a user.
+add_filter( 'wsuwp_sso_create_new_user', '__return_true' );
+add_action( 'wsuwp_sso_user_created', __NAMESPACE__ . '\\new_user', 10, 1 );
+add_action( 'admin_menu', __NAMESPACE__ . '\\user_auto_role' );
+
+/**
+ * Add new users created through the SSO plugin to the site as Subscribers,
+ * if they are in the Faculty AD group.
+ *
+ * @since 0.2.0
+ *
+ * @param int $user_id
+ */
+function new_user( $user_id ) {
+	$user = new \WP_User( $user_id );
+	$user_ad_data = WSUWP_SSO_Authentication()->refresh_user_data( $user );
+
+	if ( in_array( 'Employees.Active.Faculty', $user_ad_data['memberof'], true ) ) {
+		add_user_to_blog( get_current_blog_id(), $user_id, 'subscriber' );
+	}
+}
+/**
+ * Add logged in users in the admin screen to the site,
+ * if they are in the Faculty AD group.
+ *
+ * @since 0.2.0
+ */
+function user_auto_role() {
+	if ( is_user_logged_in() && ! is_user_member_of_blog() ) {
+		$user = new \WP_User( get_current_user_id() );
+		$user_ad_data = WSUWP_SSO_Authentication()->refresh_user_data( $user );
+
+		if ( in_array( 'Employees.Active.Faculty', $user_ad_data['memberof'], true ) ) {
+			add_user_to_blog( get_current_blog_id(), get_current_user_id(), 'subscriber' );
+			wp_safe_redirect( admin_url() );
+
+			exit;
+		}
+	}
+}


### PR DESCRIPTION
@danbleile, @clintyoung - You'll likely hear from Greg Crouch at some point about allowing faculty to vote on constituent concerns. Given what we have to work with, I believe it makes the most sense to lock this feature down to site users - and I developed the voting feature on that basis.

The intention of this pull request is to allow user signups and add existing users to the site if they are members of the Faculty AD group. The logic is based on code from the [SSO Authentication Plugin](https://github.com/washingtonstateuniversity/WSUWP-Plugin-SSO-Authentication/blob/master/includes/class-wsuwp-auth-content-visibility.php#L117), but I have **not** tested it!

It should be possible to test in a local environment by trying to log in to a site with your own NID - if you're successfully added as a subscriber, then it isn't working properly (unless you really are in the Faculty AD group for some reason). You would obviously need to have the SSO plugin activated and this theme enabled to test it out - and have the condition for loading this feature commented out.

But hopefully it does work and is ready to be deployed!